### PR TITLE
fix: Use "KEDA" instead of "keda"

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 PetSpotR allows you to use advanced AI models to report and find lost pets. It is a sample application that uses Azure Machine Learning to train a model to detect pets in images.
 
-It also leverages popular open-source projects such as Dapr and Keda to provide a scalable and resilient architecture.
+It also leverages popular open-source projects such as Dapr and KEDA to provide a scalable and resilient architecture.
 
 ![Logo](./img/logo.svg)
 


### PR DESCRIPTION
Biggest nit ever, but https://github.com/kedacore/governance/blob/main/BRANDING.md